### PR TITLE
Replace crypto:rand_bytes with crypto:strong_rand_bytes

### DIFF
--- a/src/dtlsex.erl
+++ b/src/dtlsex.erl
@@ -565,7 +565,7 @@ random_bytes(N) ->
 	    RandBytes
     catch
 	error:low_entropy ->
-	    crypto:rand_bytes(N)
+	    crypto:strong_rand_bytes(N)
     end.
 
 %%%--------------------------------------------------------------

--- a/src/dtlsex_manager.erl
+++ b/src/dtlsex_manager.erl
@@ -441,7 +441,7 @@ last_delay_timer({_,_}, TRef, {_, LastClient}) ->
 new_id(_, 0, _, _) ->
     <<>>;
 new_id(Port, Tries, Cache, CacheCb) ->
-    Id = crypto:rand_bytes(?NUM_OF_SESSION_ID_BYTES),
+    Id = crypto:strong_rand_bytes(?NUM_OF_SESSION_ID_BYTES),
     case CacheCb:lookup(Cache, {Port, Id}) of
 	undefined ->
 	    Now =  calendar:datetime_to_gregorian_seconds({date(), time()}),

--- a/src/dtlsex_record.erl
+++ b/src/dtlsex_record.erl
@@ -819,7 +819,7 @@ empty_security_params(ConnectionEnd = ?SERVER) ->
 random() ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(
 			calendar:universal_time()) - 62167219200,
-    Random_28_bytes = crypto:rand_bytes(28),
+    Random_28_bytes = crypto:strong_rand_bytes(28),
     <<?UINT32(Secs_since_1970), Random_28_bytes/binary>>.
 
 record_protocol_role(client) ->


### PR DESCRIPTION
The function crypto:rand_bytes uses OpenSSL's RAND_pseudo_bytes function,
which has been deprecated. OpenSSL recommends using RAND_bytes (which
crypto:strong_rand_bytes uses) instead.

In addition, crypto:rand_bytes will be [deprecated](https://github.com/erlang/otp/commit/1ad18832cb21fac5a5b513005f1e6a5ffd7d0329) in the R20 Erlang.